### PR TITLE
Add Xquik crawler source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Official API crawler
 X_BEARER_TOKEN=
 
+# Optional Xquik crawler
+XQUIK_API_KEY=
+
 # Optional browser login. Prefer manual login or API tokens.
 X_USERNAME=
 X_PASSWORD=

--- a/tests/test_xquik_crawler.py
+++ b/tests/test_xquik_crawler.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from x_daily_reporter.crawlers import XquikCrawler
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_xquik_crawler_maps_search_results(monkeypatch) -> None:
+    payload = {
+        "tweets": [
+            {
+                "id": "123",
+                "text": "Launch update for #AI",
+                "author": {"username": "xquik"},
+                "createdAt": "2026-06-21T04:00:00.000Z",
+                "likeCount": 5,
+                "retweetCount": 2,
+            }
+        ]
+    }
+
+    calls = []
+
+    def fake_urlopen(request, timeout):
+        calls.append((request.full_url, timeout))
+        return _Response(payload)
+
+    monkeypatch.setenv("XQUIK_API_KEY", "test-key")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    tweets = XquikCrawler().crawl("#AI", 10)
+
+    assert len(tweets) == 1
+    assert tweets[0].id == "123"
+    assert tweets[0].author == "xquik"
+    assert tweets[0].metrics["like_count"] == 5
+    assert "q=%23AI" in calls[0][0]
+    assert calls[0][1] == 30

--- a/x_daily_reporter/cli.py
+++ b/x_daily_reporter/cli.py
@@ -22,10 +22,10 @@ def main() -> int:
 
     subcommands.add_parser("login", help="Open browser login for X/Twitter")
 
-    crawl = subcommands.add_parser("crawl", help="Crawl tweets from API, browser, or file")
+    crawl = subcommands.add_parser("crawl", help="Crawl tweets from API, Xquik, browser, or file")
     crawl.add_argument("--query", required=True)
     crawl.add_argument("--limit", type=int, default=50)
-    crawl.add_argument("--source", choices=["api", "browser", "file"], default=config.source)
+    crawl.add_argument("--source", choices=["api", "xquik", "browser", "file"], default=config.source)
     crawl.add_argument("--input", type=Path, default=config.default_input)
     crawl.add_argument("--output", type=Path, default=Path("output/tweets.json"))
     crawl.add_argument("--headless", action="store_true")
@@ -42,7 +42,7 @@ def main() -> int:
     daily = subcommands.add_parser("daily", help="Crawl and report in one command")
     daily.add_argument("--query", required=True)
     daily.add_argument("--limit", type=int, default=50)
-    daily.add_argument("--source", choices=["api", "browser", "file"], default=config.source)
+    daily.add_argument("--source", choices=["api", "xquik", "browser", "file"], default=config.source)
     daily.add_argument("--input", type=Path, default=config.default_input)
     daily.add_argument("--markdown", type=Path, default=config.reports_dir / "daily-report.md")
     daily.add_argument("--json", type=Path, default=config.reports_dir / "daily-report.json")
@@ -53,7 +53,7 @@ def main() -> int:
 
     watchlist = subcommands.add_parser("watchlist", help="Run daily reports for every topic in a JSON watchlist")
     watchlist.add_argument("--config", type=Path, default=Path("config/watchlist.json"))
-    watchlist.add_argument("--source", choices=["api", "browser", "file"], default=config.source)
+    watchlist.add_argument("--source", choices=["api", "xquik", "browser", "file"], default=config.source)
     watchlist.add_argument("--input", type=Path, default=config.default_input)
     watchlist.add_argument("--reports-dir", type=Path, default=config.reports_dir)
     watchlist.add_argument("--db", type=Path, default=config.database_path)

--- a/x_daily_reporter/crawlers.py
+++ b/x_daily_reporter/crawlers.py
@@ -84,6 +84,56 @@ class XApiCrawler:
         return tweets[:limit]
 
 
+class XquikCrawler:
+    """Xquik recent-search crawler.
+
+    Requires XQUIK_API_KEY. This keeps the same Tweet model used by the
+    existing reporter pipeline while avoiding browser automation.
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("XQUIK_API_KEY")
+        if not self.api_key:
+            raise ValueError("XQUIK_API_KEY is required for Xquik crawling")
+
+    def crawl(self, query: str, limit: int) -> list[Tweet]:
+        params = {
+            "q": query,
+            "queryType": "Latest",
+            "limit": str(max(1, min(limit, 200))),
+        }
+        url = "https://xquik.com/api/v1/x/tweets/search?" + urllib.parse.urlencode(params)
+        request = urllib.request.Request(
+            url,
+            headers={"accept": "application/json", "x-api-key": self.api_key},
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        tweets: list[Tweet] = []
+        for item in payload.get("tweets", []):
+            tweet_id = str(item.get("id") or "")
+            text = str(item.get("text") or "")
+            author_payload = item.get("author") or {}
+            author = (
+                str(author_payload.get("username") or "unknown")
+                if isinstance(author_payload, dict)
+                else "unknown"
+            )
+            metrics = _xquik_metrics(item)
+            tweets.append(
+                Tweet(
+                    id=tweet_id,
+                    text=text,
+                    author=author,
+                    created_at=_parse_time(item.get("createdAt")),
+                    url=f"https://x.com/{author}/status/{tweet_id}" if tweet_id and author != "unknown" else None,
+                    metrics=metrics,
+                )
+            )
+        return tweets[:limit]
+
+
 class BrowserSearchCrawler:
     """Playwright browser fallback for manually authenticated X/Twitter sessions.
 
@@ -160,6 +210,22 @@ def _extract_author(text: str) -> str:
         if line.startswith("@"):
             return line.lstrip("@")
     return "unknown"
+
+
+def _xquik_metrics(item: dict) -> dict[str, int]:
+    fields = {
+        "like_count": "likeCount",
+        "quote_count": "quoteCount",
+        "reply_count": "replyCount",
+        "retweet_count": "retweetCount",
+        "view_count": "viewCount",
+    }
+    metrics: dict[str, int] = {}
+    for metric_name, payload_name in fields.items():
+        value = item.get(payload_name)
+        if isinstance(value, int):
+            metrics[metric_name] = value
+    return metrics
 
 
 def _offline_query_terms(query: str) -> list[str]:

--- a/x_daily_reporter/pipeline.py
+++ b/x_daily_reporter/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from x_daily_reporter.crawlers import BrowserSearchCrawler, FileCrawler, XApiCrawler
+from x_daily_reporter.crawlers import BrowserSearchCrawler, FileCrawler, XApiCrawler, XquikCrawler
 from x_daily_reporter.models import DailyReport, Tweet
 from x_daily_reporter.reporter import build_report, write_html, write_json, write_markdown
 from x_daily_reporter.storage import SQLiteReportStore
@@ -25,6 +25,8 @@ class DailyFeedPipeline:
     def crawl(self, *, source: str, query: str, limit: int, input_path: Path, headless: bool = False) -> list[Tweet]:
         if source == "api":
             return XApiCrawler().crawl(query, limit)
+        if source == "xquik":
+            return XquikCrawler().crawl(query, limit)
         if source == "browser":
             return BrowserSearchCrawler(headless=headless).crawl(query, limit)
         return FileCrawler(input_path).crawl(query, limit)


### PR DESCRIPTION
## Summary
- Add Xquik as an optional crawler source for the daily reporter
- Wire the new source into crawl, daily, and watchlist commands
- Add a focused unit test for mapping Xquik search results into the existing Tweet model

## Validation
- `python3 -m py_compile x_daily_reporter/*.py tests/test_xquik_crawler.py`
- `python3 -m pytest tests/test_xquik_crawler.py tests/test_pipeline_storage.py`
- `git diff --check`
- Public diff scan for secrets, unsupported claims, and forbidden wording
